### PR TITLE
Ice cream tweaks/fixes

### DIFF
--- a/Assets/IceCreamModule.cs
+++ b/Assets/IceCreamModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using IceCream;
 using UnityEngine;
@@ -37,8 +38,12 @@ public class IceCreamModule : MonoBehaviour
     // Mod Settings (opening times)
     class Settings
     {
-        public bool openingTimeEnabled;
-    }
+        public bool? openingTimeEnabled = null;
+	    public bool? hoursCommandEnabled = null;
+
+	    public bool OpeningTimeEnabled() { return openingTimeEnabled ?? true; }
+		public bool HoursCommandEnabled() { return hoursCommandEnabled ?? true; }
+	}
     Settings modSettings;
 
     // Flavour Definitions
@@ -130,7 +135,22 @@ public class IceCreamModule : MonoBehaviour
     {
         ModuleID = ModuleIDCounter++;
 
+	    ModSettings.RefreshSettings();
         modSettings = JsonConvert.DeserializeObject<Settings>(ModSettings.Settings);
+
+	    if (!modSettings.openingTimeEnabled.HasValue || !modSettings.hoursCommandEnabled.HasValue)
+	    {
+		    modSettings.openingTimeEnabled = modSettings.OpeningTimeEnabled();
+		    modSettings.hoursCommandEnabled = modSettings.HoursCommandEnabled();
+		    try
+		    {
+				File.WriteAllText(ModSettings.SettingsPath ,JsonConvert.SerializeObject(modSettings, Formatting.Indented));
+		    }
+		    catch
+		    {
+				//
+		    }
+	    }
 
         CorrectFlavors = new int[MaxStages];
 
@@ -304,7 +324,7 @@ public class IceCreamModule : MonoBehaviour
     void Submit()
     {
         // Check if submitted on an even minute.
-        if (!modSettings.openingTimeEnabled || (int) (BombInfo.GetTime() / 60) % 2 == 0)
+        if (!modSettings.OpeningTimeEnabled() || (int) (BombInfo.GetTime() / 60) % 2 == 0)
         {
             if (CurrentStage < MaxStages && CurrentFlavor == Solution[CurrentStage])
             {
@@ -428,7 +448,10 @@ public class IceCreamModule : MonoBehaviour
         }
 		else if (pieces.Length == 1 && pieces[0] == "hours")
 		{
-			yield return "sendtochat " + (modSettings.openingTimeEnabled ? "We are open every other hour today." : "We're open all day today!");
+			if(modSettings.HoursCommandEnabled())
+				yield return "sendtochat " + (modSettings.OpeningTimeEnabled() ? "We are open every other hour today." : "We're open all day today!");
+			else
+				yield return "sendtochat Sorry, hours are currently unavailable. Enjoy your ice cream!";
 		}
 
         var buttons = new List<KMSelectable>();

--- a/Assets/IceCreamModule.cs
+++ b/Assets/IceCreamModule.cs
@@ -382,8 +382,8 @@ public class IceCreamModule : MonoBehaviour
         }
     }
 
-    public string TwitchHelpMessage = "Move left/right with “!{0} left” and “!{0} right”. Cycle the flavours with “!{0} cycle”. Sell the currently selected flavour with “!{0} sell“. Sell a specific flavour with “!{0} sell flavour”. Check the opening hours with “!{0} hours”.";
-    public string[] TwitchValidCommands = { "^(cycle|left|right|l|r|sell|submit|middle|s|m|hours)( .*)?" };
+    [NonSerialized] public string TwitchHelpMessage = "Move left/right with “!{0} left” and “!{0} right”. Cycle the flavours with “!{0} cycle”. Sell the currently selected flavour with “!{0} sell“. Sell a specific flavour with “!{0} sell flavour”. Check the opening hours with “!{0} hours”.";
+	[NonSerialized] public string[] TwitchValidCommands = { "^(cycle|left|right|l|r|sell|submit|middle|s|m|hours)( .*)?" };
 
     public IEnumerator ProcessTwitchCommand(string command)
     {

--- a/Assets/IceCreamModule.cs
+++ b/Assets/IceCreamModule.cs
@@ -391,8 +391,14 @@ public class IceCreamModule : MonoBehaviour
 
         if (pieces.Length > 1 && (pieces[0] == "submit" || pieces[0] == "sell" || pieces[0] == "middle" || pieces[0] == "s" || pieces[0] == "m"))
         {
-            yield return null;
-            command = command.Substring(pieces[0].Length).Trim();
+	        command = command.Substring(pieces[0].Length).Trim();
+	        if (Flavours.All(x => !x.Name.StartsWith(command, StringComparison.InvariantCultureIgnoreCase)))
+	        {
+		        yield return string.Format("sendtochaterror I don't know of a flavour called {0}", command);
+		        yield break;
+	        }
+
+			yield return null;
             string originalLabel = FlavourLabel.text;
             do
             {

--- a/Assets/IceCreamModule.prefab
+++ b/Assets/IceCreamModule.prefab
@@ -1677,11 +1677,6 @@ MonoBehaviour:
   - {fileID: 2100000, guid: 70b26619f487b5148af4c660372d376e, type: 2}
   - {fileID: 2100000, guid: 5b134a82af3d70a4f9795ebe79b74525, type: 2}
   - {fileID: 2100000, guid: 5b134a82af3d70a4f9795ebe79b74525, type: 2}
-  TwitchHelpMessage: Move left/right with !{0} left and !{0} right. Cycle the flavors
-    with !{0} cycle. Sell the currently selected flavour with !{0} sell. Sell a specific
-    flavour with !{0} sell flavour
-  TwitchValidCommands:
-  - ^(cycle|left|right|l|r|sell|submit|middle|s|m)( .*)?
 --- !u!114 &114071382663949962
 MonoBehaviour:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
* Settings now update live.
* Added setting to enable/disable the hours command.
* Check to see if the requested flavour to sell is actually ever possible to sell, before attempting to sell said flavour.
* Fix help message/valid commands, so that Unity no longer serializes them.